### PR TITLE
Fetch the adapter_name from #connection_db_config

### DIFF
--- a/lib/positioning/advisory_lock.rb
+++ b/lib/positioning/advisory_lock.rb
@@ -12,17 +12,17 @@ module Positioning
       @column = column.to_s
 
       @adapters = {
-        "Mysql2" => Adapter.new(
+        "mysql2" => Adapter.new(
           initialise: -> {},
           aquire: -> { connection.execute "SELECT GET_LOCK(#{connection.quote(lock_name)}, -1)" },
           release: -> { connection.execute "SELECT RELEASE_LOCK(#{connection.quote(lock_name)})" }
         ),
-        "PostgreSQL" => Adapter.new(
+        "postgresql" => Adapter.new(
           initialise: -> {},
           aquire: -> { connection.execute "SELECT pg_advisory_lock(#{lock_name.hex & 0x7FFFFFFFFFFFFFFF})" },
           release: -> { connection.execute "SELECT pg_advisory_unlock(#{lock_name.hex & 0x7FFFFFFFFFFFFFFF})" }
         ),
-        "SQLite" => Adapter.new(
+        "sqlite3" => Adapter.new(
           initialise: -> {
             FileUtils.mkdir_p "#{Dir.pwd}/tmp"
             filename = "#{Dir.pwd}/tmp/#{lock_name}.lock"
@@ -63,7 +63,7 @@ module Positioning
     end
 
     def adapter_name
-      connection.adapter_name
+      base_class.connection_db_config.adapter
     end
 
     def adapter


### PR DESCRIPTION
... instead of from #connection.

Calling #connection actually sets up a connection with the database
if you don't have any yet. This can cause problems because (quote):

> Ideally, database connections are not opened from Rails initializers.
> Opening a database connection (for example, checking the database exists,
> or making a database query) from an initializer means that tasks like
> db:drop, and db:test:prepare will fail because an active session prevents
> the database from being dropped.

See https://gitlab-org.gitlab.io/technical-writing-group/gitlab-docs-hugo/development/rails_initializers/

Putting `position on:` in a model caused the AdvisoryLock to run
`adapter.initialise.call` (line 42) which ultimately called #connection
on line 61 (via #adapter and #adapter_name.