### PR TITLE
Attempt to fix unwanted position update

### DIFF
--- a/lib/positioning/mechanisms.rb
+++ b/lib/positioning/mechanisms.rb
@@ -117,7 +117,8 @@ module Positioning
 
       case position_before_type_cast
       when Integer
-        self.position = position_before_type_cast.clamp(1..last_position)
+        clamped_position = position_before_type_cast.clamp(1..last_position)
+        self.position = clamped_position unless self.position == clamped_position
       when :first, {after: nil}, {after: ""}
         self.position = 1
       when nil, "", :last, {before: nil}, {before: ""}


### PR DESCRIPTION
The function `position_changed?` returns true even if the position remains the same. This because the corresponding method on the positioned object (`@positioned.position_changed?`) returns true due to the following code in `positioning.rb` and, in particular the first line of the redefined method:
```
          redefine_method(:"#{column}=") do |position|
            send :"#{column}_will_change!"
            super(position)
          end
```

Probably, my change could be moved to the above method but, since I don't really understand the reason behind that `will_change!`, I think that this version is less risky.