### PR TITLE
Support opting out of Advisory Lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ positioned on: :type
 belongs_to :list
 belongs_to :category
 positioned on: [:list, :category, :enabled]
+
+# If Advisory Lock does not fit with your environment, you can disable it entirely by passing the 'use_advisory_lock' flag as false
+belongs_to :list
+positioned on: :list, use_advisory_lock: false
 ```
 
 ### Manipulating Positioning
@@ -242,6 +246,24 @@ You're encouraged to review the Advisory Lock code to ensure it fits with your e
 https://github.com/brendon/positioning/blob/main/lib/positioning/advisory_lock.rb
 
 If you have any concerns or improvements please file a GitHub issue.
+
+### Opting out of Advisory Lock
+
+You can opt out of Advisory Lock by setting `use_advisory_lock` as `false` when declaring positioning:
+
+```ruby
+belongs_to :list
+positioned on: :list, use_advisory_lock: false
+```
+
+When disabling Advisory Lock, you still want to avoid race conditions. There are multiple ways to achieve that, one of them is locking the parent record manually:
+
+```ruby
+list = List.create(name: "My list")
+list.with_lock do
+  list.items.create(name: "My list item")
+end
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ belongs_to :list
 belongs_to :category
 positioned on: [:list, :category, :enabled]
 
-# If Advisory Lock does not fit with your environment, you can disable it entirely by passing the 'use_advisory_lock' flag as false
+# If you do not want to use Advisory Lock, you can disable it entirely by passing the 'advisory_lock' flag as false
 belongs_to :list
-positioned on: :list, use_advisory_lock: false
+positioned on: :list, advisory_lock: false
 ```
 
 ### Manipulating Positioning
@@ -249,20 +249,29 @@ If you have any concerns or improvements please file a GitHub issue.
 
 ### Opting out of Advisory Lock
 
-You can opt out of Advisory Lock by setting `use_advisory_lock` as `false` when declaring positioning:
+There are cases where Advisory Lock may be unwanted or unnecessary, for instance, if you already lock the parent record in **every** operation that will touch the database on the positioned item, **everywhere** in your application.
+
+Example of such scenario in your application:
+
+```ruby
+list = List.create(name: "List")
+
+list.with_lock do
+  item_a = list.items.create(name: "Item A")
+  item_b = list.items.create(name: "Item B")
+  item_c = list.items.create(name: "Item C")
+
+  item_c.update(position: {before: item_a})
+
+  item_a.destroy
+end
+```
+
+Therefore, making sure you already have another mechanism to avoid race conditions, you can opt out of Advisory Lock by setting `advisory_lock` to `false` when declaring positioning:
 
 ```ruby
 belongs_to :list
-positioned on: :list, use_advisory_lock: false
-```
-
-When disabling Advisory Lock, you still want to avoid race conditions. There are multiple ways to achieve that, one of them is locking the parent record manually:
-
-```ruby
-list = List.create(name: "My list")
-list.with_lock do
-  list.items.create(name: "My list item")
-end
+positioned on: :list, advisory_lock: false
 ```
 
 ## Development

--- a/lib/positioning.rb
+++ b/lib/positioning.rb
@@ -18,7 +18,7 @@ module Positioning
         @positioning_columns ||= {}
       end
 
-      def positioned(on: [], column: :position)
+      def positioned(on: [], column: :position, use_advisory_lock: true)
         unless base_class?
           raise Error.new "can't be called on an abstract class or STI subclass."
         end
@@ -43,18 +43,22 @@ module Positioning
             super(position)
           end
 
-          advisory_lock = AdvisoryLock.new(base_class, column)
+          if use_advisory_lock
+            advisory_lock = AdvisoryLock.new(base_class, column)
 
-          before_create advisory_lock
-          before_update advisory_lock
-          before_destroy advisory_lock
+            before_create advisory_lock
+            before_update advisory_lock
+            before_destroy advisory_lock
+          end
 
           before_create { Mechanisms.new(self, column).create_position }
           before_update { Mechanisms.new(self, column).update_position }
           before_destroy { Mechanisms.new(self, column).destroy_position }
 
-          after_commit advisory_lock
-          after_rollback advisory_lock
+          if use_advisory_lock
+            after_commit advisory_lock
+            after_rollback advisory_lock
+          end
         end
       end
     end

--- a/lib/positioning.rb
+++ b/lib/positioning.rb
@@ -18,7 +18,7 @@ module Positioning
         @positioning_columns ||= {}
       end
 
-      def positioned(on: [], column: :position, use_advisory_lock: true)
+      def positioned(on: [], column: :position, advisory_lock: true)
         unless base_class?
           raise Error.new "can't be called on an abstract class or STI subclass."
         end
@@ -43,21 +43,21 @@ module Positioning
             super(position)
           end
 
-          if use_advisory_lock
-            advisory_lock = AdvisoryLock.new(base_class, column)
+          if advisory_lock
+            advisory_lock_callback = AdvisoryLock.new(base_class, column)
 
-            before_create advisory_lock
-            before_update advisory_lock
-            before_destroy advisory_lock
+            before_create advisory_lock_callback
+            before_update advisory_lock_callback
+            before_destroy advisory_lock_callback
           end
 
           before_create { Mechanisms.new(self, column).create_position }
           before_update { Mechanisms.new(self, column).update_position }
           before_destroy { Mechanisms.new(self, column).destroy_position }
 
-          if use_advisory_lock
-            after_commit advisory_lock
-            after_rollback advisory_lock
+          if advisory_lock
+            after_commit advisory_lock_callback
+            after_rollback advisory_lock_callback
           end
         end
       end

--- a/test/models/item_without_advisory_lock.rb
+++ b/test/models/item_without_advisory_lock.rb
@@ -1,0 +1,5 @@
+class ItemWithoutAdvisoryLock < ActiveRecord::Base
+  belongs_to :list
+
+  positioned on: :list, use_advisory_lock: false
+end

--- a/test/models/item_without_advisory_lock.rb
+++ b/test/models/item_without_advisory_lock.rb
@@ -1,5 +1,5 @@
 class ItemWithoutAdvisoryLock < ActiveRecord::Base
   belongs_to :list
 
-  positioned on: :list, use_advisory_lock: false
+  positioned on: :list, advisory_lock: false
 end

--- a/test/models/list.rb
+++ b/test/models/list.rb
@@ -1,4 +1,5 @@
 class List < ActiveRecord::Base
   has_many :items, -> { order(:position) }, dependent: :destroy
+  has_many :item_without_advisory_locks, -> { order(:position) }, dependent: :destroy
   has_many :authors, -> { order(:position) }, dependent: :destroy
 end

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -21,6 +21,14 @@ ActiveRecord::Migration.suppress_messages do
 
     add_index :items, [:list_id, :position], unique: true
 
+    create_table :item_without_advisory_locks, force: true do |t|
+      t.string :name
+      t.integer :position, null: false
+      t.references :list, null: false
+    end
+
+    add_index :item_without_advisory_locks, [:list_id, :position], unique: true
+
     create_table :categories, force: true do |t|
       t.string :name
       t.integer :position, null: false

--- a/test/test_positioning.rb
+++ b/test/test_positioning.rb
@@ -55,8 +55,8 @@ class TestTransactionSafety < Minitest::Test
     list = List.create name: "List"
     items = []
 
-    10.times do
-      threads = 20.times.map do
+    2.times do
+      threads = 3.times.map do
         Thread.new do
           ActiveRecord::Base.connection_pool.with_connection do
             list.with_lock do
@@ -69,6 +69,65 @@ class TestTransactionSafety < Minitest::Test
     end
 
     assert_equal (1..items.length).to_a, list.item_without_advisory_locks.map(&:position)
+
+    list.destroy
+  end
+
+  def test_no_duplicate_row_values_when_updating_and_advisory_lock_is_disabled_and_parent_record_is_locked
+    ActiveRecord::Base.connection_handler.clear_all_connections!
+
+    list = List.create name: "List"
+    item_a = list.item_without_advisory_locks.create name: "Item A"
+    item_b = list.item_without_advisory_locks.create name: "Item B"
+    item_c = list.item_without_advisory_locks.create name: "Item C"
+
+    2.times do
+      threads = 3.times.map do
+        Thread.new do
+          ActiveRecord::Base.connection_pool.with_connection do
+            list.with_lock do
+              item_c.update(position: {before: item_a})
+            end
+          end
+        end
+      end
+      threads.each(&:join)
+    end
+
+    assert_equal item_c.reload.position, 1
+    assert_equal item_a.reload.position, 2
+    assert_equal item_b.reload.position, 3
+
+    list.destroy
+  end
+
+  def test_no_duplicate_row_values_when_destroying_and_advisory_lock_is_disabled_and_parent_record_is_locked
+    ActiveRecord::Base.connection_handler.clear_all_connections!
+
+    list = List.create name: "List"
+    items = []
+    ["A", "B", "C", "D", "E", "F", "G", "H"].each do |name|
+      items << list.item_without_advisory_locks.create(name: name)
+    end
+
+    2.times do
+      threads = 3.times.map do
+        Thread.new do
+          ActiveRecord::Base.connection_pool.with_connection do
+            list.with_lock do
+              items.first.destroy
+              items.shift
+            end
+          end
+        end
+      end
+      threads.each(&:join)
+    end
+
+    items.each(&:reload)
+
+    assert_equal items.sort_by(&:position).pluck(:position, :name), [[1, "G"], [2, "H"]]
+    assert_equal list.item_without_advisory_locks.order(:position).pluck(:position, :name), [[1, "G"], [2, "H"]]
 
     list.destroy
   end


### PR DESCRIPTION
There are scenarios where Advisory Lock is not the best approach.

I have added the support to disable it by passing the `use_advisory_lock` as `false` when declaring positing.

